### PR TITLE
Increase time between notification updates

### DIFF
--- a/OpenPods/app/build.gradle
+++ b/OpenPods/app/build.gradle
@@ -8,7 +8,7 @@ android {
         targetSdkVersion 28
         versionCode 8
         versionName '0.8'
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 }

--- a/OpenPods/app/src/main/java/com/dosse/airpods/IntroActivity.java
+++ b/OpenPods/app/src/main/java/com/dosse/airpods/IntroActivity.java
@@ -5,12 +5,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Settings;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
 

--- a/OpenPods/app/src/main/java/com/dosse/airpods/MainActivity.java
+++ b/OpenPods/app/src/main/java/com/dosse/airpods/MainActivity.java
@@ -2,16 +2,14 @@ package com.dosse.airpods;
 
 import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
-import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.os.Build;
 import android.os.PowerManager;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;

--- a/OpenPods/app/src/main/java/com/dosse/airpods/NoBTActivity.java
+++ b/OpenPods/app/src/main/java/com/dosse/airpods/NoBTActivity.java
@@ -1,6 +1,6 @@
 package com.dosse.airpods;
 
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 
 public class NoBTActivity extends AppCompatActivity {

--- a/OpenPods/app/src/main/java/com/dosse/airpods/PodsService.java
+++ b/OpenPods/app/src/main/java/com/dosse/airpods/PodsService.java
@@ -24,7 +24,7 @@ import android.os.Build;
 import android.os.IBinder;
 import android.os.ParcelUuid;
 import android.os.SystemClock;
-import android.support.v4.app.NotificationCompat;
+import androidx.core.app.NotificationCompat;
 import android.util.Log;
 import android.view.View;
 import android.widget.RemoteViews;

--- a/OpenPods/build.gradle
+++ b/OpenPods/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/OpenPods/gradle.properties
+++ b/OpenPods/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Really please do not merge this, I just created it to open up some discussion about the insane number of updates to the notification battery status.

Correct me if I am wrong, the for loop runs infinitely to check and update the battery status with a sleep time of 1 second. This seems pretty inefficient and battery draining.

Furthermore, there is no need to update the notification every second as the battery levels of the airpods are not exact values but in multiples of 5. This means that the battery levels would remain the same for quite sometime before it changes -- making the update every second irrelevant.

What I have come-up with to reduce the number of updates is very hacky and does not cover a lot of edge cases. I hope that you might have something else in mind to separate the notification updates from the update checks.