### PR TITLE
Workaround for Dark Mode on SDK < 29

### DIFF
--- a/OpenPods/app/src/main/res/layout/location_disabled_big.xml
+++ b/OpenPods/app/src/main/res/layout/location_disabled_big.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="120dp"
+    android:background="@color/bgColorPrimary"
     android:gravity="center"
     android:padding="12dp">
 

--- a/OpenPods/app/src/main/res/layout/location_disabled_small.xml
+++ b/OpenPods/app/src/main/res/layout/location_disabled_small.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="70dp"
+    android:background="@color/bgColorPrimary"
     android:gravity="center"
     android:padding="12dp">
 

--- a/OpenPods/app/src/main/res/layout/status_big.xml
+++ b/OpenPods/app/src/main/res/layout/status_big.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@color/bgColorPrimary"
     android:gravity="center"
     android:padding="12dp"
     tools:ignore="RtlHardcoded,ContentDescription">

--- a/OpenPods/app/src/main/res/layout/status_small.xml
+++ b/OpenPods/app/src/main/res/layout/status_small.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="@color/bgColorPrimary"
     android:gravity="center"
     android:padding="12dp"
     tools:ignore="RtlHardcoded,ContentDescription">

--- a/OpenPods/app/src/main/res/values-night/colors.xml
+++ b/OpenPods/app/src/main/res/values-night/colors.xml
@@ -3,7 +3,9 @@
     <color name="colorPrimary"     >#448AFF</color>
     <color name="colorPrimaryDark" >#0D47A1</color>
     <color name="colorAccent"      >#448AFF</color>
-    <color name="textColorPrimary" >#FFFFFF</color>
+
+    <color name="textColorPrimary" >#FFF</color>
+    <color name="bgColorPrimary"   >#000</color>
 
     <color name="white">#FFFFFF</color>
     <color name="black">#000000</color>

--- a/OpenPods/app/src/main/res/values/colors.xml
+++ b/OpenPods/app/src/main/res/values/colors.xml
@@ -3,7 +3,9 @@
     <color name="colorPrimary"     >#448AFF</color>
     <color name="colorPrimaryDark" >#0D47A1</color>
     <color name="colorAccent"      >#448AFF</color>
-    <color name="textColorPrimary" >#000000</color>
+
+    <color name="textColorPrimary" >#000</color>
+    <color name="bgColorPrimary"   >#FFF</color>
 
     <color name="white">#FFFFFF</color>
     <color name="black">#000000</color>

--- a/OpenPods/gradle/wrapper/gradle-wrapper.properties
+++ b/OpenPods/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip


### PR DESCRIPTION
This should fix #68 where Dark Mode isn't properly implemented on Android 9 (SDK 28) and lower. 