### PR TITLE
Bugfix: Recreate RemoteViews on every iteration

### DIFF
--- a/OpenPods/app/src/main/java/com/dosse/airpods/PodsService.java
+++ b/OpenPods/app/src/main/java/com/dosse/airpods/PodsService.java
@@ -290,7 +290,6 @@ public class PodsService extends Service {
             boolean notificationShowing = false;
             String compat = getPackageManager().getInstallerPackageName(getPackageName());
 
-            RemoteViews[] notificationArr = new RemoteViews[] {new RemoteViews(getPackageName(), R.layout.status_big), new RemoteViews(getPackageName(), R.layout.status_small)};
             RemoteViews[] notificationLocation = new RemoteViews[] {new RemoteViews(getPackageName(), R.layout.location_disabled_big), new RemoteViews(getPackageName(), R.layout.location_disabled_small)};
 
             NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(PodsService.this, TAG);
@@ -300,6 +299,8 @@ public class PodsService extends Service {
             mBuilder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
             for (; ; ) {
+                RemoteViews[] notificationArr = new RemoteViews[] {new RemoteViews(getPackageName(), R.layout.status_big), new RemoteViews(getPackageName(), R.layout.status_small)};
+
                 /*&&System.currentTimeMillis()-lastSeenConnected<TIMEOUT_CONNECTED*/
                 if (maybeConnected && !(leftStatus == 15 && rightStatus == 15 && caseStatus == 15)) {
                     if (!notificationShowing) {


### PR DESCRIPTION
 Fix a memory leak caused by trying to update the same RemoteViews. Instead of trying to update them, create them from scratch on every iteration.

 The memory leak on RemoteViews caused the Parcel to get very big and therefore undeliverable by the Samsung NotificationService.

 See https://stackoverflow.com/a/4484693/6797552

Fixes #107