### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <item name="colorPrimary"     >@color/colorPrimary</item>
         <item name="colorPrimaryDark" >@color/colorPrimaryDark</item>
         <item name="colorAccent"      >@color/colorAccent</item>
+        <item name="titleTextColor"   >#141414</item>
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color and the background color does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#141414') are as follows:
![image](https://user-images.githubusercontent.com/101503193/158400547-7ec23c71-3585-4a8c-b69c-074cde01ca51.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.