### PR TITLE
Properly handle POST_NOTIFICATION permission for Android 13

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/app/src/main/java/com/dosse/airpods/ui/IntroActivity.java
+++ b/app/src/main/java/com/dosse/airpods/ui/IntroActivity.java
@@ -28,8 +28,8 @@ public class IntroActivity extends AppCompatActivity {
     private TextView msg;
     private Button btn;
 
-    private static final int STEP_PERMISSION_BLUETOOTH = 1, STEP_PERMISSION_BATTERY_OPTIMIZATION = 2, STEP_PERMISSION_LOCATION = 3, STEP_PERMISSION_BACKGROUND_LOCATION = 4;
-    private static final int BLUETOOTH_REQUEST_CODE = 101, LOCATION_REQUEST_CODE = 102, BACKGROUND_LOCATION_REQUEST_CODE = 103;
+    private static final int STEP_PERMISSION_BLUETOOTH = 1, STEP_PERMISSION_BATTERY_OPTIMIZATION = 2, STEP_PERMISSION_LOCATION = 3, STEP_PERMISSION_BACKGROUND_LOCATION = 4, STEP_PERMISSION_NOTIFICATION = 5;
+    private static final int BLUETOOTH_REQUEST_CODE = 101, LOCATION_REQUEST_CODE = 102, BACKGROUND_LOCATION_REQUEST_CODE = 103, NOTIFICATION_REQUEST_CODE = 104;
 
     @Override
     protected void onCreate (Bundle savedInstanceState) {
@@ -74,14 +74,15 @@ public class IntroActivity extends AppCompatActivity {
             return STEP_PERMISSION_LOCATION;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) if (!PermissionUtils.getBackgroundLocationPermission(this))
             return STEP_PERMISSION_BACKGROUND_LOCATION;
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) if (!PermissionUtils.getNotificationPermissions(this))
+            return STEP_PERMISSION_NOTIFICATION;
         return 0;
     }
 
     @SuppressLint("BatteryLife")
     private void initScreen () {
         int currentStep = getPermissionState() - ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) ? 0 : 1);
-        int numOfSteps = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) ? ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) ? 4 : 3) : 2;
+        int numOfSteps = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) ? 5 : (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) ? ((Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) ? 4 : 3) : 2;
 
         runOnUiThread(() -> {
             switch (getPermissionState()) {
@@ -112,6 +113,11 @@ public class IntroActivity extends AppCompatActivity {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) requestPermissions(new String[] {Manifest.permission.ACCESS_BACKGROUND_LOCATION}, BACKGROUND_LOCATION_REQUEST_CODE);
                     });
                     break;
+                case STEP_PERMISSION_NOTIFICATION:
+                    msg.setText(String.format(Locale.getDefault(), "%s %d/%d: %s", getString(R.string.intro_step), currentStep, numOfSteps, getString(R.string.intro_notif_perm)));
+                    btn.setOnClickListener(view -> {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) requestPermissions(new String[] {Manifest.permission.POST_NOTIFICATIONS}, NOTIFICATION_REQUEST_CODE);
+                    });
             }
             btn.setText(String.format(Locale.getDefault(), "%s (%d/%d)", getString(R.string.intro_allow), currentStep, numOfSteps));
         });
@@ -129,6 +135,9 @@ public class IntroActivity extends AppCompatActivity {
                 break;
             case BACKGROUND_LOCATION_REQUEST_CODE:
                 if (!hasAllPermissionsGranted(grantResults)) Toast.makeText(this, getString(R.string.msg_loc2_perm), Toast.LENGTH_LONG).show();
+                break;
+            case NOTIFICATION_REQUEST_CODE:
+                if (!hasAllPermissionsGranted(grantResults)) Toast.makeText(this, getString(R.string.msg_notif_perm), Toast.LENGTH_LONG).show();
                 break;
         }
     }

--- a/app/src/main/java/com/dosse/airpods/utils/PermissionUtils.java
+++ b/app/src/main/java/com/dosse/airpods/utils/PermissionUtils.java
@@ -21,6 +21,11 @@ public class PermissionUtils {
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    public static boolean getNotificationPermissions (Context context) {
+        return checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED;
+    }
+
     @RequiresApi(api = Build.VERSION_CODES.S)
     public static boolean getBluetoothPermissions (Context context) {
         return checkSelfPermission(context, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
@@ -44,6 +49,8 @@ public class PermissionUtils {
     }
 
     public static boolean checkAllPermissions (Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            return getNotificationPermissions(context) && getBatteryOptimizationsPermission(context) && getLocationPermissions(context) && getBluetoothPermissions(context);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
             return getBatteryOptimizationsPermission(context) && getLocationPermissions(context) && getBluetoothPermissions(context);
         else

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,9 +14,11 @@
     <string name="intro_bat_perm" tools:ignore="MissingTranslation">Battery Optimization</string>
     <string name="intro_loc1_perm" tools:ignore="MissingTranslation">Location Permission</string>
     <string name="intro_loc2_perm" tools:ignore="MissingTranslation">Background Location Permission</string>
+    <string name="intro_notif_perm" tools:ignore="MissingTranslation">Notification Permission</string>
     <string name="msg_bt_perm" tools:ignore="MissingTranslation">Bluetooth permissions not granted, please enable them in settings.</string>
     <string name="msg_loc1_perm" tools:ignore="MissingTranslation">Location permission not granted, please enable it in settings.</string>
     <string name="msg_loc2_perm" tools:ignore="MissingTranslation">Background Location permission not granted, please enable it in settings.</string>
+    <string name="msg_notif_perm" tools:ignore="MissingTranslation">Notification Permission not granted, please enable it in settings.</string>
 
     <string name="main_description">The app will show a notification when your AirPods are connected</string>
     <string name="supportedDevicesTitle"><u>Supported devices:</u></string>


### PR DESCRIPTION
Since Android 13, Google introduced the POST_NOTIFICATION permission to only allow an app to post notifications if the permission is granted at runtime.

This small PR adds in the required logic to ask for the permission on Android 13 and above.