### PR TITLE
Added sending broadcast function for integration with other apps

### DIFF
--- a/app/src/main/java/com/dosse/airpods/pods/BroadcastParam.java
+++ b/app/src/main/java/com/dosse/airpods/pods/BroadcastParam.java
@@ -1,0 +1,14 @@
+package com.dosse.airpods.pods;
+
+public class BroadcastParam {
+    public static final String ACTION_STATUS = "com.dosse.airpods.status";
+    public static final String EXTRA_IS_ALL_DISCONNECTED = "isAllDisconnected";
+    public static final String EXTRA_MODEL = "model";
+    public static final String EXTRA_IS_SINGLE = "isSingle";
+    public static final String EXTRA_LEFT_POD_STATUS = "leftPodStatus";
+    public static final String EXTRA_RIGHT_POD_STATUS = "rightPodStatus";
+    public static final String EXTRA_POD_CASE_STATUS = "caseStatus";
+    public static final String EXTRA_LEFT_POD_IN_EAR = "leftPodInEar";
+    public static final String EXTRA_RIGHT_POD_IN_EAR = "rightPodInEar";
+    public static final String EXTRA_SINGLE_POD_STATUS = "singlePodStatus";
+}

--- a/app/src/main/java/com/dosse/airpods/pods/models/RegularPods.java
+++ b/app/src/main/java/com/dosse/airpods/pods/models/RegularPods.java
@@ -22,6 +22,12 @@ public class RegularPods implements IPods {
         return pods[pos].parseStatus();
     }
 
+    public boolean isInEar(int pos) {
+
+
+        return pods[pos].isInEar();
+    }
+
     public int getInEarVisibility(int pos) {
         return pods[pos].inEarVisibility();
     }


### PR DESCRIPTION
I wanted to have Airpod integration in my own custom launcher and this seems to be a nice way to do so.  I appreciate the community's effort in reverse engineering this :+1: 

Usage:

**Intent parameters**
```java
public static final String ACTION_STATUS = "com.dosse.airpods.status";
public static final String EXTRA_IS_ALL_DISCONNECTED = "isAllDisconnected";
public static final String EXTRA_MODEL = "model";
public static final String EXTRA_IS_SINGLE = "isSingle";
public static final String EXTRA_LEFT_POD_STATUS = "leftPodStatus";
public static final String EXTRA_RIGHT_POD_STATUS = "rightPodStatus";
public static final String EXTRA_POD_CASE_STATUS = "caseStatus";
public static final String EXTRA_LEFT_POD_IN_EAR = "leftPodInEar";
public static final String EXTRA_RIGHT_POD_IN_EAR = "rightPodInEar";
public static final String EXTRA_SINGLE_POD_STATUS = "singlePodStatus";
```

**AndroidManifest.xml**
```xml
<receiver android:name=".AirpodReceiver"
    android:exported="true">
    <intent-filter>
        <action android:name="com.dosse.airpods.status"/>
    </intent-filter>
</receiver>
```

**Receiver**
```java
public class AirpodReceiver extends BroadcastReceiver {
    @Override
    public void onReceive(Context context, Intent intent) {
        if (intent.getAction().equals(ACTION_STATUS)) {
           // Do something with "intent.getExtras()" here
        }
    }
}
```

**Register Receiver**
```java
IntentFilter airpodFilter = new IntentFilter(ACTION_STATUS);
AirpodReceiver airpodReceiver = new AirpodReceiver();
registerReceiver(airpodReceiver, airpodFilter);
```
